### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
 dist: trusty
 php:
-  - '5.6'
-  - '7.0'
   - '7.1'
   - '7.2'
-  - 'hhvm'
+  - '7.3'
 install:
   - composer update
 script:

--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,13 @@
     "homepage": "https://github.com/divineomega/php-postcodes",
     "license": "LGPL-3.0-only",
     "require": {
-        "php": ">=5.5.9",
+        "php": "^7.1",
         "guzzlehttp/guzzle": "~6.0",
         "fzaninotto/faker": "^1.6",
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^7.0 || ^8.0",
         "fzaninotto/faker": "^1.6",
         "php-coveralls/php-coveralls": "^2.0"
     },

--- a/tests/Unit/BasicUsageTest.php
+++ b/tests/Unit/BasicUsageTest.php
@@ -8,22 +8,48 @@ use PHPUnit\Framework\TestCase;
 
 final class BasicUsageTest extends TestCase
 {
-    public function testValidation()
+    public function validationProvider()
     {
-        $postcodes = ['ST163DP', 'TN30YA', 'ST78PP', 'CM233WE', 'E16AW', 'E106QX', 'ST16 3DP', 'st16 3dp'];
-
-        foreach ($postcodes as $postcode) {
-            $this->assertTrue(Validator::validatePostcode($postcode));
-        }
+        return [
+            ['ST163DP'],
+            ['TN30YA'],
+            ['ST78PP'],
+            ['CM233WE'],
+            ['E16AW'],
+            ['E106QX'],
+            ['ST16 3DP'],
+            ['st16 3dp'],
+        ];
     }
 
-    public function testValidationFailure()
+    /**
+     * @dataProvider validationProvider
+     */
+    public function testValidation($postcode)
     {
-        $postcodes = ['ST163DPA', 'XF2P90', 'Ollie', 'cake', 'ST16 3DPA', 'KT18 5DN', 'AB15 4YR', 'B62 8RS'];
+        $this->assertTrue(Validator::validatePostcode($postcode));
+    }
 
-        foreach ($postcodes as $postcode) {
-            $this->assertFalse(Validator::validatePostcode($postcode));
-        }
+    public function validationFailureProvider()
+    {
+        return [
+            ['ST163DPA'],
+            ['XF2P90'],
+            ['Ollie'],
+            ['cake'],
+            ['ST16 3DPA'],
+            ['KT18 5DN'],
+            ['AB15 4YR'],
+            ['B62 8RS'],
+        ];
+    }
+
+    /**
+     * @dataProvider validationFailureProvider
+     */
+    public function testValidationFailure($postcode)
+    {
+        $this->assertFalse(Validator::validatePostcode($postcode));
     }
 
     public function testGeneration()
@@ -39,9 +65,9 @@ final class BasicUsageTest extends TestCase
         }
     }
 
-    public function testOutwardAndInwardCodes()
+    public function outwardAndInwardCodesProvider()
     {
-        $postcodeTestItems = [
+        return [
             [
                 'postcode' => 'ST163DP',
                 'outward'  => 'ST16',
@@ -88,24 +114,30 @@ final class BasicUsageTest extends TestCase
                 'inward'   => '6AW',
             ],
         ];
+    }
 
-        foreach ($postcodeTestItems as $postcodeTestItem) {
-            $this->assertEquals($postcodeTestItem['outward'], Tokenizer::outward($postcodeTestItem['postcode']));
-            $this->assertEquals($postcodeTestItem['inward'], Tokenizer::inward($postcodeTestItem['postcode']));
-        }
+    /**
+     * @dataProvider outwardAndInwardCodesProvider
+     */
+    public function testOutwardAndInwardCodes($postcode, $outward, $inward)
+    {
+        $this->assertEquals($outward, Tokenizer::outward($postcode));
+        $this->assertEquals($inward, Tokenizer::inward($postcode));
     }
 
     public function testOutwardCodeWithInvalidPostcode()
     {
         $this->expectException(InvalidPostcodeException::class);
+        $this->expectExceptionMessage('Post code provided is not valid');
 
-        $outward = Tokenizer::outward('ST163DPA');
+        Tokenizer::outward('ST163DPA');
     }
 
     public function testInwardCodeWithInvalidPostcode()
     {
         $this->expectException(InvalidPostcodeException::class);
+        $this->expectExceptionMessage('Post code provided is not valid');
 
-        $outward = Tokenizer::inward('ST163DPA');
+        Tokenizer::inward('ST163DPA');
     }
 }


### PR DESCRIPTION
# Changed log
- Remove the unsupported PHP versions that official PHP team doesn't support.
- Add the `php-7.3` version in Travis CI build because this version is stable.
- Set the different PHPUnit versions to support different PHP versions.
- Using the `DataProvider` to collect test cases and this approach can separate test cases from test methods.